### PR TITLE
Add Xcode project for ArcGISMapApp

### DIFF
--- a/ArcGISMapApp/ArcGISMapApp.xcodeproj/project.pbxproj
+++ b/ArcGISMapApp/ArcGISMapApp.xcodeproj/project.pbxproj
@@ -1,0 +1,367 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {};
+objectVersion = 60;
+objects = {
+
+/* Begin PBXBuildFile section */
+AA0D01502B01D5A7009B5E5A /* ArcGISMapAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0D01492B01D5A7009B5E5A /* ArcGISMapAppApp.swift */; };
+AA0D01512B01D5A7009B5E5A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0D014A2B01D5A7009B5E5A /* ContentView.swift */; };
+AA0D01522B01D5BC009B5E5A /* ArcGIS in Frameworks */ = {isa = PBXBuildFile; productRef = AA0D015F2B01D77A009B5E5A /* ArcGIS */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+AA0D01442B01D5A7009B5E5A /* ArcGISMapApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ArcGISMapApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+AA0D01492B01D5A7009B5E5A /* ArcGISMapAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArcGISMapAppApp.swift; sourceTree = "<group>"; };
+AA0D014A2B01D5A7009B5E5A /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+AA0D014B2B01D5A7009B5E5A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Resources/Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+AA0D013F2B01D5A7009B5E5A /* Frameworks */ = {
+isa = PBXFrameworksBuildPhase;
+buildActionMask = 2147483647;
+files = (
+AA0D01522B01D5BC009B5E5A /* ArcGIS in Frameworks */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+AA0D013B2B01D5A6009B5E5A = {
+isa = PBXGroup;
+children = (
+AA0D014C2B01D5A7009B5E5A /* ArcGISMapApp */,
+AA0D01432B01D5A6009B5E5A /* Products */,
+);
+sourceTree = "<group>";
+};
+AA0D01432B01D5A6009B5E5A /* Products */ = {
+isa = PBXGroup;
+children = (
+AA0D01442B01D5A7009B5E5A /* ArcGISMapApp.app */,
+);
+name = Products;
+sourceTree = "<group>";
+};
+AA0D014C2B01D5A7009B5E5A /* ArcGISMapApp */ = {
+isa = PBXGroup;
+children = (
+AA0D014D2B01D5A7009B5E5A /* Sources */,
+AA0D014E2B01D5A7009B5E5A /* Resources */,
+);
+path = ArcGISMapApp;
+sourceTree = "<group>";
+};
+AA0D014D2B01D5A7009B5E5A /* Sources */ = {
+isa = PBXGroup;
+children = (
+AA0D01492B01D5A7009B5E5A /* ArcGISMapAppApp.swift */,
+AA0D014A2B01D5A7009B5E5A /* ContentView.swift */,
+);
+name = Sources;
+sourceTree = "<group>";
+};
+AA0D014E2B01D5A7009B5E5A /* Resources */ = {
+isa = PBXGroup;
+children = (
+AA0D014B2B01D5A7009B5E5A /* Info.plist */,
+);
+path = Resources;
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+AA0D013E2B01D5A6009B5E5A /* ArcGISMapApp */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = AA0D015A2B01D64C009B5E5A /* Build configuration list for PBXNativeTarget "ArcGISMapApp" */;
+buildPhases = (
+AA0D013D2B01D5A6009B5E5A /* Sources */,
+AA0D013F2B01D5A7009B5E5A /* Frameworks */,
+AA0D01402B01D5A7009B5E5A /* Resources */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = ArcGISMapApp;
+packageProductDependencies = (
+AA0D015F2B01D77A009B5E5A /* ArcGIS */,
+);
+productName = ArcGISMapApp;
+productReference = AA0D01442B01D5A7009B5E5A /* ArcGISMapApp.app */;
+productType = "com.apple.product-type.application";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+AA0D013C2B01D5A6009B5E5A /* Project object */ = {
+isa = PBXProject;
+attributes = {
+BuildIndependentTargetsInParallel = 1;
+LastSwiftUpdateCheck = 1600;
+LastUpgradeCheck = 1600;
+TargetAttributes = {
+AA0D013E2B01D5A6009B5E5A = {
+CreatedOnToolsVersion = 16.0;
+};
+};
+};
+buildConfigurationList = AA0D01572B01D64C009B5E5A /* Build configuration list for PBXProject "ArcGISMapApp" */;
+compatibilityVersion = "Xcode 16.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+knownRegions = (
+en,
+Base,
+);
+mainGroup = AA0D013B2B01D5A6009B5E5A;
+packageReferences = (
+AA0D015E2B01D77A009B5E5A /* XCRemoteSwiftPackageReference "arcgis-maps-sdk-swift" */,
+);
+productRefGroup = AA0D01432B01D5A6009B5E5A /* Products */;
+projectDirPath = "";
+projectRoot = "";
+targets = (
+AA0D013E2B01D5A6009B5E5A /* ArcGISMapApp */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+AA0D01402B01D5A7009B5E5A /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+AA0D013D2B01D5A6009B5E5A /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+AA0D01512B01D5A7009B5E5A /* ContentView.swift in Sources */,
+AA0D01502B01D5A7009B5E5A /* ArcGISMapAppApp.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+AA0D01582B01D64C009B5E5A /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGNING_REQUIRED = NO;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = dwarf;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+ENABLE_TESTABILITY = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_DYNAMIC_NO_PIC = NO;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_OPTIMIZATION_LEVEL = 0;
+GCC_PREPROCESSOR_DEFINITIONS = (
+"DEBUG=1",
+"$(inherited)",
+);
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+ONLY_ACTIVE_ARCH = YES;
+SDKROOT = iphoneos;
+SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+SWIFT_VERSION = 6.0;
+};
+name = Debug;
+};
+AA0D01592B01D64C009B5E5A /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ALWAYS_SEARCH_USER_PATHS = NO;
+CLANG_ANALYZER_NONNULL = YES;
+CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+CLANG_ENABLE_MODULES = YES;
+CLANG_ENABLE_OBJC_ARC = YES;
+CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+CLANG_WARN_BOOL_CONVERSION = YES;
+CLANG_WARN_COMMA = YES;
+CLANG_WARN_CONSTANT_CONVERSION = YES;
+CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+CLANG_WARN_EMPTY_BODY = YES;
+CLANG_WARN_ENUM_CONVERSION = YES;
+CLANG_WARN_INFINITE_RECURSION = YES;
+CLANG_WARN_INT_CONVERSION = YES;
+CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+CLANG_WARN_STRICT_PROTOTYPES = YES;
+CLANG_WARN_SUSPICIOUS_MOVE = YES;
+CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+CODE_SIGNING_REQUIRED = NO;
+COPY_PHASE_STRIP = NO;
+DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+ENABLE_NS_ASSERTIONS = NO;
+ENABLE_STRICT_OBJC_MSGSEND = YES;
+GCC_C_LANGUAGE_STANDARD = gnu17;
+GCC_NO_COMMON_BLOCKS = YES;
+GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+GCC_WARN_UNDECLARED_SELECTOR = YES;
+GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+GCC_WARN_UNUSED_FUNCTION = YES;
+GCC_WARN_UNUSED_VARIABLE = YES;
+IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+MTL_ENABLE_DEBUG_INFO = NO;
+SDKROOT = iphoneos;
+SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+SWIFT_VERSION = 6.0;
+};
+name = Release;
+};
+AA0D015B2B01D64C009B5E5A /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CODE_SIGN_STYLE = Automatic;
+CURRENT_PROJECT_VERSION = 1;
+DEVELOPMENT_ASSET_PATHS = "";
+DEVELOPMENT_TEAM = "";
+ENABLE_PREVIEWS = YES;
+GENERATE_INFOPLIST_FILE = NO;
+INFOPLIST_FILE = ArcGISMapApp/Resources/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+MARKETING_VERSION = 1.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.example.ArcGISMapApp;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SDKROOT = iphoneos;
+SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+SWIFT_EMIT_LOC_STRINGS = NO;
+SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+SWIFT_VERSION = 6.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Debug;
+};
+AA0D015C2B01D64C009B5E5A /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+CODE_SIGN_STYLE = Automatic;
+CURRENT_PROJECT_VERSION = 1;
+DEVELOPMENT_ASSET_PATHS = "";
+DEVELOPMENT_TEAM = "";
+GENERATE_INFOPLIST_FILE = NO;
+INFOPLIST_FILE = ArcGISMapApp/Resources/Info.plist;
+IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+LD_RUNPATH_SEARCH_PATHS = (
+"$(inherited)",
+"@executable_path/Frameworks",
+);
+MARKETING_VERSION = 1.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.example.ArcGISMapApp;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SDKROOT = iphoneos;
+SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+SWIFT_COMPILATION_MODE = wholemodule;
+SWIFT_EMIT_LOC_STRINGS = NO;
+SWIFT_OPTIMIZATION_LEVEL = "-O";
+SWIFT_VERSION = 6.0;
+TARGETED_DEVICE_FAMILY = "1,2";
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+AA0D01572B01D64C009B5E5A /* Build configuration list for PBXProject "ArcGISMapApp" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+AA0D01582B01D64C009B5E5A /* Debug */,
+AA0D01592B01D64C009B5E5A /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+AA0D015A2B01D64C009B5E5A /* Build configuration list for PBXNativeTarget "ArcGISMapApp" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+AA0D015B2B01D64C009B5E5A /* Debug */,
+AA0D015C2B01D64C009B5E5A /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+AA0D015E2B01D77A009B5E5A /* XCRemoteSwiftPackageReference "arcgis-maps-sdk-swift" */ = {
+isa = XCRemoteSwiftPackageReference;
+repositoryURL = "https://github.com/Esri/arcgis-maps-sdk-swift";
+requirement = {
+kind = upToNextMajorVersion;
+minimumVersion = 200.8.0;
+};
+};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+AA0D015F2B01D77A009B5E5A /* ArcGIS */ = {
+isa = XCSwiftPackageProductDependency;
+productName = ArcGIS;
+};
+/* End XCSwiftPackageProductDependency section */
+
+};
+rootObject = AA0D013C2B01D5A6009B5E5A /* Project object */;
+}

--- a/ArcGISMapApp/ArcGISMapApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ArcGISMapApp/ArcGISMapApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ArcGISMapApp/ArcGISMapApp.xcodeproj/xcshareddata/xcschemes/ArcGISMapApp.xcscheme
+++ b/ArcGISMapApp/ArcGISMapApp.xcodeproj/xcshareddata/xcschemes/ArcGISMapApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA0D013E2B01D5A6009B5E5A"
+               BuildableName = "ArcGISMapApp.app"
+               BlueprintName = "ArcGISMapApp"
+               ReferencedContainer = "container:ArcGISMapApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA0D013E2B01D5A6009B5E5A"
+            BuildableName = "ArcGISMapApp.app"
+            BlueprintName = "ArcGISMapApp"
+            ReferencedContainer = "container:ArcGISMapApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA0D013E2B01D5A6009B5E5A"
+            BuildableName = "ArcGISMapApp.app"
+            BlueprintName = "ArcGISMapApp"
+            ReferencedContainer = "container:ArcGISMapApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ArcGISMapApp/ArcGISMapApp/ArcGISMapAppApp.swift
+++ b/ArcGISMapApp/ArcGISMapApp/ArcGISMapAppApp.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import ArcGIS
+
+@main
+struct ArcGISMapAppApp: App {
+    init() {
+        // TODO: Replace with your ArcGIS API key.
+        ArcGISEnvironment.apiKey = APIKey("<#Your ArcGIS API Key#>")
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ArcGISMapApp/ArcGISMapApp/ContentView.swift
+++ b/ArcGISMapApp/ArcGISMapApp/ContentView.swift
@@ -1,0 +1,43 @@
+import ArcGIS
+import SwiftUI
+
+struct ContentView: View {
+    @State private var map = Map(basemapStyle: .arcGISTopographic)
+    @StateObject private var locationDisplay = LocationDisplay(dataSource: DefaultLocationDataSource())
+    @State private var locationError: Error?
+
+    var body: some View {
+        MapView(map: map, locationDisplay: locationDisplay)
+            .onAppear {
+                Task {
+                    await startLocationDisplay()
+                }
+            }
+            .alert("Location Error", isPresented: Binding(
+                get: { locationError != nil },
+                set: { if !$0 { locationError = nil } }
+            )) {
+                Button("OK", role: .cancel) { locationError = nil }
+            } message: {
+                if let locationError {
+                    Text(locationError.localizedDescription)
+                }
+            }
+    }
+
+    @MainActor
+    private func startLocationDisplay() async {
+        guard !locationDisplay.isStarted else { return }
+        do {
+            try await locationDisplay.dataSource.start()
+            locationDisplay.autoPanMode = .recenter
+            try await locationDisplay.start()
+        } catch {
+            locationError = error
+        }
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ArcGISMapApp/ArcGISMapApp/Resources/Info.plist
+++ b/ArcGISMapApp/ArcGISMapApp/Resources/Info.plist
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UIRequiresFullScreen</key>
+    <true/>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>This app requires your location to center the map on your position.</string>
+</dict>
+</plist>

--- a/ArcGISMapApp/README.md
+++ b/ArcGISMapApp/README.md
@@ -1,0 +1,34 @@
+# ArcGISMapApp
+
+A minimal SwiftUI sample that displays an ArcGIS basemap and tracks the user's current location. The project targets iOS 18 and uses Swift 6.2, Xcode 26, and ArcGIS Maps SDK for Swift 200.8.
+
+## Requirements
+
+- Xcode 26
+- iOS 18 SDK
+- Swift 6.2 toolchain
+- ArcGIS Maps SDK for Swift 200.8 (added through Swift Package Manager)
+- A valid ArcGIS API key with privileges to access basemap and location services
+
+## Setup
+
+1. Open **ArcGISMapApp.xcodeproj** (create it from the included sources using the iOS App template if cloning the repo).
+2. Add the ArcGIS Maps SDK for Swift 200.8 package:
+   - In Xcode, select **File > Add Package Dependencies...**.
+   - Use the package URL `https://github.com/Esri/arcgis-maps-sdk-swift.git`.
+   - Set the dependency rule to **Exact Version: 200.8.0** and add the **ArcGIS** product to the target.
+3. Replace the placeholder in `ArcGISMapAppApp.swift` with your ArcGIS API key.
+4. Ensure the app has the `NSLocationWhenInUseUsageDescription` key in its Info.plist. The provided Info.plist already contains a sample message.
+5. Build and run the app on an iOS 18 simulator or device that has location services enabled.
+
+## Features
+
+- Displays a topographic basemap using ArcGIS Maps SDK for Swift.
+- Requests the user's permission to access their location when the map view appears.
+- Automatically recenters the map to the user's current location when available.
+- Shows an alert if location access fails or is unavailable.
+
+## Notes
+
+- The preview in `ContentView.swift` requires macOS Sonoma or later when using Xcode 26.
+- On first launch, the system prompt requests location permission. Denying permission prevents the map from recentering on the user; the map will remain at the default extent.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# Fresh start
+# ArcGISMapApp Sample
+
+This repository contains a minimal SwiftUI application that demonstrates how to display an ArcGIS basemap and track the user's current location on iOS 18 using Swift 6.2, Xcode 26, and ArcGIS Maps SDK for Swift 200.8. See [`ArcGISMapApp/README.md`](ArcGISMapApp/README.md) for setup details.


### PR DESCRIPTION
## Summary
- add an Xcode project and shared scheme for the ArcGIS SwiftUI sample app
- configure the target for Swift 6, iOS 18, and ArcGIS Maps SDK for Swift 200.8 via Swift Package Manager

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1873c48b88332bf320ec5258adbb4